### PR TITLE
Add per-block 'Disable on mobile' toggle for parallax

### DIFF
--- a/src/frontend.js
+++ b/src/frontend.js
@@ -17,11 +17,8 @@
 		'(prefers-reduced-motion: reduce)'
 	).matches;
 
-	// Check for mobile (matches CSS media query)
-	const isMobile = window.matchMedia( '(max-width: 768px)' ).matches;
-
-	// Skip parallax if reduced motion or mobile
-	if ( prefersReducedMotion || isMobile ) {
+	// Skip parallax entirely if reduced motion is preferred
+	if ( prefersReducedMotion ) {
 		return;
 	}
 
@@ -32,16 +29,30 @@
 	let parallaxItems = [];
 
 	/**
+	 * Check if viewport is mobile-sized.
+	 */
+	function isMobile() {
+		return window.matchMedia( '(max-width: 768px)' ).matches;
+	}
+
+	/**
 	 * Initialize parallax elements.
+	 * Filters out blocks with "disable on mobile" when on a mobile viewport.
 	 */
 	function initParallax() {
 		const containers = document.querySelectorAll(
 			'.wp-block-cover.has-parallax-scroll'
 		);
 
+		const mobile = isMobile();
 		parallaxItems = [];
 
 		containers.forEach( ( container ) => {
+			// Skip this block on mobile if "disable on mobile" is enabled
+			if ( mobile && container.dataset.parallaxHideMobile === 'true' ) {
+				return;
+			}
+
 			// Find the background element (image, video, or color overlay)
 			const background =
 				container.querySelector( '.wp-block-cover__image-background' ) ||
@@ -51,7 +62,7 @@
 				container.querySelector( ':scope > video' );
 
 			if ( background ) {
-				// Read speed from data attribute, default to 0.5
+				// Read speed from data attribute
 				const speed = parseFloat(
 					container.dataset.parallaxSpeed || DEFAULT_SPEED
 				);
@@ -116,20 +127,16 @@
 	}
 
 	/**
-	 * Handle resize - reinitialize to recalculate dimensions.
+	 * Handle resize - reinitialize to recalculate dimensions and
+	 * re-evaluate per-block mobile settings.
 	 */
 	function onResize() {
-		// Check if we should disable on mobile after resize
-		if ( window.matchMedia( '(max-width: 768px)' ).matches ) {
-			// Reset transforms and remove listener
-			parallaxItems.forEach( ( item ) => {
-				item.background.style.transform = '';
-			} );
-			window.removeEventListener( 'scroll', onScroll, { passive: true } );
-			return;
-		}
+		// Reset existing transforms
+		parallaxItems.forEach( ( item ) => {
+			item.background.style.transform = '';
+		} );
 
-		// Reinitialize
+		// Reinitialize - initParallax filters per-block mobile settings
 		initParallax();
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -270,6 +270,10 @@ function addParallaxAttribute( settings, name ) {
 				type: 'number',
 				default: DEFAULT_SPEED,
 			},
+			parallaxHideOnMobile: {
+				type: 'boolean',
+				default: false,
+			},
 		},
 	};
 }
@@ -290,7 +294,7 @@ const withParallaxControl = createHigherOrderComponent( ( BlockEdit ) => {
 		}
 
 		const { attributes, setAttributes } = props;
-		const { hasParallaxScroll, hasParallax, parallaxSpeed = DEFAULT_SPEED } = attributes;
+		const { hasParallaxScroll, hasParallax, parallaxSpeed = DEFAULT_SPEED, parallaxHideOnMobile } = attributes;
 
 		// Track previous hasParallax value to detect when it's enabled
 		const prevHasParallax = useRef( hasParallax );
@@ -418,6 +422,18 @@ const withParallaxControl = createHigherOrderComponent( ( BlockEdit ) => {
 								) }
 							</div>
 						) }
+
+						{ hasParallaxScroll && (
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Disable on mobile', 'cover-parallax-style' ) }
+								checked={ !! parallaxHideOnMobile }
+								onChange={ ( value ) => {
+									setAttributes( { parallaxHideOnMobile: value } );
+								} }
+								help={ __( 'Disable parallax effect on mobile devices for performance.', 'cover-parallax-style' ) }
+							/>
+						) }
 					</PanelBody>
 				</InspectorControls>
 			</>
@@ -446,14 +462,19 @@ function addParallaxPropsToSave( props, blockType, attributes ) {
 
 	if ( attributes.hasParallaxScroll ) {
 		const speed = attributes.parallaxSpeed || DEFAULT_SPEED;
-
-		return {
+		const saveProps = {
 			...props,
 			className: props.className
 				? `${ props.className } has-parallax-scroll`
 				: 'has-parallax-scroll',
 			'data-parallax-speed': speed,
 		};
+
+		if ( attributes.parallaxHideOnMobile ) {
+			saveProps[ 'data-parallax-hide-mobile' ] = 'true';
+		}
+
+		return saveProps;
 	}
 
 	return props;
@@ -483,14 +504,20 @@ const withParallaxPropsInEditor = createHigherOrderComponent( ( BlockListBlock )
 				? `${ props.className } has-parallax-scroll`
 				: 'has-parallax-scroll';
 
+			const wrapperProps = {
+				...props.wrapperProps,
+				'data-parallax-speed': speed,
+			};
+
+			if ( attributes.parallaxHideOnMobile ) {
+				wrapperProps[ 'data-parallax-hide-mobile' ] = 'true';
+			}
+
 			return (
 				<BlockListBlock
 					{ ...props }
 					className={ className }
-					wrapperProps={ {
-						...props.wrapperProps,
-						'data-parallax-speed': speed,
-					} }
+					wrapperProps={ wrapperProps }
 				/>
 			);
 		}

--- a/src/style.scss
+++ b/src/style.scss
@@ -63,13 +63,13 @@
 	}
 }
 
-/* Mobile optimization: Disable parallax on smaller screens for performance */
+/* Mobile optimization: Disable parallax on smaller screens when per-block option is set */
 @media (max-width: 768px) {
-	.wp-block-cover.has-parallax-scroll .wp-block-cover__background,
-	.wp-block-cover.has-parallax-scroll .wp-block-cover__image-background,
-	.wp-block-cover.has-parallax-scroll .wp-block-cover__video-background,
-	.wp-block-cover.has-parallax-scroll > img:not(.wp-block-cover__image-background),
-	.wp-block-cover.has-parallax-scroll > video {
+	.wp-block-cover.has-parallax-scroll[data-parallax-hide-mobile="true"] .wp-block-cover__background,
+	.wp-block-cover.has-parallax-scroll[data-parallax-hide-mobile="true"] .wp-block-cover__image-background,
+	.wp-block-cover.has-parallax-scroll[data-parallax-hide-mobile="true"] .wp-block-cover__video-background,
+	.wp-block-cover.has-parallax-scroll[data-parallax-hide-mobile="true"] > img:not(.wp-block-cover__image-background),
+	.wp-block-cover.has-parallax-scroll[data-parallax-hide-mobile="true"] > video {
 		top: 0;
 		height: 100%;
 		transform: none !important;


### PR DESCRIPTION
## Summary
- Adds `parallaxHideOnMobile` boolean attribute to the Cover block
- Adds a "Disable on mobile" toggle in the parallax settings panel (visible when parallax is enabled)
- Saves as `data-parallax-hide-mobile="true"` on the block HTML
- Frontend JS filters out blocks with this attribute on mobile viewports, while other parallax blocks remain active
- CSS resets parallax styling for these blocks at `max-width: 768px`
- Previously parallax was globally disabled on all mobile blocks — now it's per-block opt-in

Fixes #4, fixes #7, fixes #8

**Note:** Supersedes PR #15 (`fix/7-8-resize-viewport-bugs`). The global mobile early exit removal and simplified resize handler here resolve both viewport/resize bugs while also adding the requested per-block control.

## Test plan
- [ ] Add two Cover blocks with parallax — enable "Disable on mobile" on only one
- [ ] Preview on mobile viewport — the flagged block shows static background, the other still has parallax
- [ ] Resize to desktop — both blocks have parallax active
- [ ] Toggle "Disable on mobile" off — both blocks have parallax on mobile too
- [ ] Load page at mobile width, resize to desktop — parallax activates (verifies #7 fix)
- [ ] Resize mobile → desktop → mobile → desktop — parallax toggles correctly each time (verifies #8 fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)